### PR TITLE
Prolly trees integration

### DIFF
--- a/block.js
+++ b/block.js
@@ -25,7 +25,7 @@ export class MemoryBlockstore {
    * @param {Uint8Array} bytes
    */
   async put (cid, bytes) {
-    console.log('put', cid)
+    // console.log('put', cid)
     this.#blocks.set(cid.toString(), bytes)
   }
 

--- a/block.js
+++ b/block.js
@@ -25,6 +25,7 @@ export class MemoryBlockstore {
    * @param {Uint8Array} bytes
    */
   async put (cid, bytes) {
+    console.log('put', cid)
     this.#blocks.set(cid.toString(), bytes)
   }
 
@@ -66,7 +67,9 @@ export class MultiBlockFetcher {
   async get (link) {
     for (const f of this.#fetchers) {
       const v = await f.get(link)
-      if (v) return v
+      if (v) {
+        return v
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "archy": "^1.0.0",
         "cli-color": "^2.0.3",
         "multiformats": "^11.0.1",
+        "prolly-trees": "^0.2.0",
         "sade": "^1.8.1"
       },
       "bin": {
@@ -396,6 +397,33 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -403,6 +431,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -432,6 +470,29 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/builtins": {
       "version": "5.0.1",
@@ -1710,6 +1771,25 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -1757,8 +1837,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.4",
@@ -2491,6 +2570,17 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "node_modules/node-sql-parser": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-3.9.4.tgz",
+      "integrity": "sha512-U8xa/QBpNz/dc4BERBkMg//XTrBDcj0uIg5YDYPV4ChYgHPEw4JhoT5YWTxQuKBg/3C1kfkTO4MuEYw7fCYHJw==",
+      "dependencies": {
+        "big-integer": "^1.6.48"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2833,6 +2923,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prolly-trees": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/prolly-trees/-/prolly-trees-0.2.0.tgz",
+      "integrity": "sha512-XetRs6Tf2RCGgBphcTyWcvvPULdCdYI4pAIvsPF5lCmiT8tkq3RqO0+aJSIH8+73tIDuDIAwEH24+VtLnnNZbQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "node-sql-parser": "^3.1.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -2887,6 +2986,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -3027,7 +3139,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3185,6 +3296,14 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -3410,6 +3529,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -3857,11 +3981,31 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3887,6 +4031,15 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "builtins": {
       "version": "5.0.1",
@@ -4832,6 +4985,11 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -4867,8 +5025,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.4",
@@ -5406,6 +5563,14 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "node-sql-parser": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-3.9.4.tgz",
+      "integrity": "sha512-U8xa/QBpNz/dc4BERBkMg//XTrBDcj0uIg5YDYPV4ChYgHPEw4JhoT5YWTxQuKBg/3C1kfkTO4MuEYw7fCYHJw==",
+      "requires": {
+        "big-integer": "^1.6.48"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5648,6 +5813,15 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prolly-trees": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/prolly-trees/-/prolly-trees-0.2.0.tgz",
+      "integrity": "sha512-XetRs6Tf2RCGgBphcTyWcvvPULdCdYI4pAIvsPF5lCmiT8tkq3RqO0+aJSIH8+73tIDuDIAwEH24+VtLnnNZbQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "node-sql-parser": "^3.1.0"
+      }
+    },
     "prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5685,6 +5859,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
     },
     "readdirp": {
       "version": "3.6.0",
@@ -5770,8 +5954,7 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex-test": {
       "version": "1.0.0",
@@ -5860,6 +6043,14 @@
         "minimist": "^1.2.6",
         "pkg-conf": "^3.1.0",
         "xdg-basedir": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "string-width": {
@@ -6034,6 +6225,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "archy": "^1.0.0",
     "cli-color": "^2.0.3",
     "multiformats": "^11.0.1",
+    "prolly-trees": "^0.2.0",
     "sade": "^1.8.1"
   },
   "devDependencies": {

--- a/prolly.js
+++ b/prolly.js
@@ -1,0 +1,274 @@
+import * as Clock from './clock.js'
+import { EventFetcher, EventBlock } from './clock.js'
+import { create, load } from 'prolly-trees/src/db-index.js'
+import { nocache as cache } from 'prolly-trees/src/cache.js'
+import { bf } from 'prolly-trees/src/utils.js'
+import * as codec from '@ipld/dag-cbor'
+import { sha256 as hasher } from 'multiformats/hashes/sha2'
+
+import { Block, MemoryBlockstore, MultiBlockFetcher } from './block.js'
+
+/**
+ * @typedef {{
+ *   type: 'put'|'del'
+ *   key: string
+ *   value: import('./link').AnyLink
+ *   root: import('./shard').ShardLink
+ * }} EventData
+ * @typedef {{
+ *   root: import('./shard').ShardLink
+ *   head: import('./clock').EventLink<EventData>[]
+ *   event: import('./clock').EventBlockView<EventData>
+ * } & import('./index').ShardDiff} Result
+ */
+
+const opts = { cache, chunker: bf(3), codec, hasher }
+
+/**
+ * Put a value (a CID) for the given key. If the key exists it's value is
+ * overwritten.
+ *
+ * @param {import('./block').BlockFetcher} blocks Bucket block storage.
+ * @param {import('./clock').EventLink<EventData>[]} head Merkle clock head.
+ * @param {string} key The key of the value to put.
+ * @param {import('./link').AnyLink} value The value to put.
+ * @param {object} [options]
+ * @returns {Promise<Result>}
+ */
+export async function put (blocks, head, key, value, options) {
+  const mblocks = new MemoryBlockstore()
+  blocks = new MultiBlockFetcher(mblocks, blocks)
+
+  if (!head.length) {
+    // create a new db-index with a list of key,value
+    const { get, put } = blocks
+    let root
+    const additions = []
+    for await (const node of create({ get, list: [{ key, value }], ...opts })) {
+      const block = await node.block
+      await put(block.cid, block.bytes)
+      mblocks.putSync(block.cid, block.bytes)
+      additions.push(block)
+      root = block
+    }
+    /** @type {EventData} */
+    const data = { type: 'put', root, key, value }
+    const event = await EventBlock.create(data, head)
+    head = await Clock.advance(blocks, head, event.cid)
+    return {
+      root,
+      additions,
+      removals: [],
+      head,
+      event
+    }
+  }
+
+  const events = new EventFetcher(blocks)
+  const ancestor = await findCommonAncestor(events, head)
+  if (!ancestor) throw new Error('failed to find common ancestor event')
+
+  const aevent = await events.get(ancestor)
+  let { root } = aevent.value.data
+
+  const sorted = await findSortedEvents(events, head, ancestor)
+  const additions = new Map()
+  const removals = new Map()
+
+  for (const { value: event } of sorted) {
+    if (!['put', 'del'].includes(event.data.type)) {
+      throw new Error(`unknown event type: ${event.data.type}`)
+    }
+    const result = event.data.type === 'put'
+      ? await Pail.put(blocks, root, event.data.key, event.data.value)
+      : await Pail.del(blocks, root, event.data.key)
+
+    root = result.root
+    for (const a of result.additions) {
+      mblocks.putSync(a.cid, a.bytes)
+      additions.set(a.cid.toString(), a)
+    }
+    for (const r of result.removals) {
+      removals.set(r.cid.toString(), r)
+    }
+  }
+
+  const result = await Pail.put(blocks, root, key, value, options)
+  for (const a of result.additions) {
+    mblocks.putSync(a.cid, a.bytes)
+    additions.set(a.cid.toString(), a)
+  }
+  for (const r of result.removals) {
+    removals.set(r.cid.toString(), r)
+  }
+
+  /** @type {EventData} */
+  const data = { type: 'put', root: result.root, key, value }
+  const event = await EventBlock.create(data, head)
+  mblocks.putSync(event.cid, event.bytes)
+  head = await Clock.advance(blocks, head, event.cid)
+
+  return {
+    root: result.root,
+    additions: Array.from(additions.values()),
+    removals: Array.from(removals.values()),
+    head,
+    event
+  }
+}
+
+/**
+ * Determine the effective pail root given the current merkle clock head.
+ *
+ * @param {import('./block').BlockFetcher} blocks Bucket block storage.
+ * @param {import('./clock').EventLink<EventData>[]} head Merkle clock head.
+ */
+export async function root (blocks, head) {
+  if (!head.length) return
+
+  const mblocks = new MemoryBlockstore()
+  blocks = new MultiBlockFetcher(mblocks, blocks)
+
+  const events = new EventFetcher(blocks)
+  const ancestor = await findCommonAncestor(events, head)
+  if (!ancestor) throw new Error('failed to find common ancestor event')
+
+  const aevent = await events.get(ancestor)
+  let { root } = aevent.value.data
+
+  const sorted = await findSortedEvents(events, head, ancestor)
+  for (const { value: event } of sorted) {
+    if (!['put', 'del'].includes(event.data.type)) {
+      throw new Error(`unknown event type: ${event.data.type}`)
+    }
+    const result = event.data.type === 'put'
+      ? await Pail.put(blocks, root, event.data.key, event.data.value)
+      : await Pail.del(blocks, root, event.data.key)
+
+    root = result.root
+    for (const a of result.additions) {
+      mblocks.putSync(a.cid, a.bytes)
+    }
+  }
+
+  return root
+}
+
+/**
+ * @param {import('./block').BlockFetcher} blocks Bucket block storage.
+ * @param {import('./clock').EventLink<EventData>[]} head Merkle clock head.
+ * @param {string} key The key of the value to retrieve.
+ */
+export async function get (blocks, head, key) {
+  return Pail.get(blocks, await root(blocks, head), key)
+}
+
+/**
+ * Find the common ancestor event of the passed children. A common ancestor is
+ * the first single event in the DAG that _all_ paths from children lead to.
+ *
+ * @param {import('./clock').EventFetcher} events
+ * @param  {import('./clock').EventLink<EventData>[]} children
+ */
+async function findCommonAncestor (events, children) {
+  if (!children.length) return
+  const candidates = children.map(c => [c])
+  while (true) {
+    let changed = false
+    for (const c of candidates) {
+      const candidate = await findAncestorCandidate(events, c[c.length - 1])
+      if (!candidate) continue
+      changed = true
+      c.push(candidate)
+      const ancestor = findCommonString(candidates)
+      if (ancestor) return ancestor
+    }
+    if (!changed) return
+  }
+}
+
+/**
+ * @param {import('./clock').EventFetcher} events
+ * @param {import('./clock').EventLink<EventData>} root
+ */
+async function findAncestorCandidate (events, root) {
+  const { value: event } = await events.get(root)
+  if (!event.parents.length) return root
+  return event.parents.length === 1
+    ? event.parents[0]
+    : findCommonAncestor(events, event.parents)
+}
+
+/**
+ * @template {{ toString: () => string }} T
+ * @param  {Array<T[]>} arrays
+ */
+function findCommonString (arrays) {
+  arrays = arrays.map(a => [...a])
+  for (const arr of arrays) {
+    for (const item of arr) {
+      let matched = true
+      for (const other of arrays) {
+        if (arr === other) continue
+        matched = other.some(i => String(i) === String(item))
+        if (!matched) break
+      }
+      if (matched) return item
+    }
+  }
+}
+
+/**
+ * Find and sort events between the head(s) and the tail.
+ * @param {import('./clock').EventFetcher} events
+ * @param {import('./clock').EventLink<EventData>[]} head
+ * @param {import('./clock').EventLink<EventData>} tail
+ */
+async function findSortedEvents (events, head, tail) {
+  // get weighted events - heavier events happened first
+  /** @type {Map<string, { event: import('./clock').EventBlockView<EventData>, weight: number }>} */
+  const weights = new Map()
+  const all = await Promise.all(head.map(h => findEvents(events, h, tail)))
+  for (const arr of all) {
+    for (const { event, depth } of arr) {
+      const info = weights.get(event.cid.toString())
+      if (info) {
+        info.weight += depth
+      } else {
+        weights.set(event.cid.toString(), { event, weight: depth })
+      }
+    }
+  }
+
+  // group events into buckets by weight
+  /** @type {Map<number, import('./clock').EventBlockView<EventData>[]>} */
+  const buckets = new Map()
+  for (const { event, weight } of weights.values()) {
+    const bucket = buckets.get(weight)
+    if (bucket) {
+      bucket.push(event)
+    } else {
+      buckets.set(weight, [event])
+    }
+  }
+
+  // sort by weight, and by CID within weight
+  return Array.from(buckets)
+    .sort((a, b) => b[0] - a[0])
+    .flatMap(([, es]) => es.sort((a, b) => String(a.cid) < String(b.cid) ? -1 : 1))
+}
+
+/**
+ * @param {import('./clock').EventFetcher} events
+ * @param {import('./clock').EventLink<EventData>} start
+ * @param {import('./clock').EventLink<EventData>} end
+ * @returns {Promise<Array<{ event: import('./clock').EventBlockView<EventData>, depth: number }>>}
+ */
+async function findEvents (events, start, end, depth = 0) {
+  const event = await events.get(start)
+  const acc = [{ event, depth }]
+  const { parents } = event.value
+  if (parents.length === 1 && String(parents[0]) === String(end)) return acc
+  const rest = await Promise.all(parents.map(p => findEvents(events, p, end, depth + 1)))
+  return acc.concat(...rest)
+}

--- a/prolly.js
+++ b/prolly.js
@@ -93,6 +93,8 @@ export async function put (inBlocks, head, key, value, options) {
 
   const aevent = await events.get(ancestor)
   const { root } = aevent.value.data
+
+  // todo instead of loading it every time, we should be able to just make it part of the THIS
   const prollyRootNode = await load({ cid: root.cid, get, ...opts })
 
   const sorted = await findSortedEvents(events, head, ancestor)
@@ -162,7 +164,8 @@ export async function put (inBlocks, head, key, value, options) {
   const event = await EventBlock.create(data, head)
   mblocks.putSync(event.cid, event.bytes)
   head = await Clock.advance(blocks, head, event.cid)
-  console.log('additions', additions.size)
+  // console.log('additions', additions.size, Array.from(additions.values()).map(v => v.cid.toString()).sort())
+  // console.log('additions', additions.size)
   return {
     root: finalProllyRootBlock,
     additions: Array.from(additions.values()),

--- a/prolly.js
+++ b/prolly.js
@@ -169,6 +169,8 @@ export async function put (inBlocks, head, key, value, options) {
  * @param {import('./clock').EventLink<EventData>[]} head Merkle clock head.
  */
 export async function root (blocks, head) {
+  console.log('root.head', head)
+
   if (!head.length) return
 
   const mblocks = new MemoryBlockstore()
@@ -205,10 +207,14 @@ export async function root (blocks, head) {
  * @param {string} key The key of the value to retrieve.
  */
 export async function get (blocks, head, key) {
+  const get = async (address) => {
+    const { cid, bytes } = await blocks.get(address)
+    return createBlock({ cid, bytes, hasher, codec })
+  }
   const rootBlock = await root(blocks, head)
   const prollyRootNode = await load({ cid: rootBlock.cid, get, ...opts })
-  const result = prollyRootNode.get(key)
-  console.log(result)
+  console.log('key', key)
+  const result = await prollyRootNode.get(key)
   return result
 }
 

--- a/prolly.js
+++ b/prolly.js
@@ -204,7 +204,7 @@ export async function root (blocks, head) {
       mblocks.putSync(a.cid, a.bytes)
     }
   }
-  return await prollyRootNode.address
+  return await prollyRootOut.block.cid
 }
 
 /**
@@ -214,6 +214,7 @@ export async function root (blocks, head) {
  */
 export async function get (blocks, head, key) {
   const get = async (address) => {
+    console.log('address', address)
     const { cid, bytes } = await blocks.get(address)
     return createBlock({ cid, bytes, hasher, codec })
   }

--- a/test/crdt.test.js
+++ b/test/crdt.test.js
@@ -17,6 +17,11 @@ describe('CRDT', () => {
     assert.equal(event.value.data.value.toString(), value.toString())
     assert.equal(head.length, 1)
     assert.equal(head[0].toString(), event.cid.toString())
+
+    const avalue = await alice.get('key')
+    assert(avalue)
+    console.log('crdt avalue', avalue)
+    assert.equal(avalue.toString(), value.toString())
   })
 
   it('linear put multiple values', async () => {

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -11,6 +11,7 @@ describe('Prolly', () => {
     const alice = new TestPail(blocks, [])
     const key = 'key'
     const value = await randomCID(32)
+    console.log('expexted', value)
     const { event, head } = await alice.putAndVis(key, value)
 
     assert.equal(event.value.data.type, 'put')
@@ -19,6 +20,10 @@ describe('Prolly', () => {
     assert.equal(head.length, 1)
     assert.equal(head[0].toString(), event.cid.toString())
 
+    console.log('alive event', event)
+    // next steps to debug <- *****************************************************************
+    // log the CIDs and their values that are written by the putAndVis
+    // log the CIDs and their values that are read by the get
     const avalue = await alice.get('key')
     assert(avalue)
     console.log('prolly avalue', avalue)

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -72,6 +72,7 @@ describe('Prolly', () => {
     // get item put to bob
     const avalue = await alice.get(data[1][0])
     assert(avalue)
+    console.log('avalue', avalue)
     assert.equal(avalue.toString(), data[1][1].toString())
 
     // get item put to alice
@@ -140,7 +141,6 @@ class TestPail {
 
   /** @param {string} key */
   async get (key) {
-    console.log('this.head', this.head)
     return get(this.blocks, this.head, key)
   }
 }

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -11,7 +11,7 @@ describe('Prolly', () => {
     const alice = new TestPail(blocks, [])
     const key = 'key'
     const value = await randomCID(32)
-    console.log('expexted', value)
+    console.log('expected value, not in blocks', value)
     const { event, head } = await alice.putAndVis(key, value)
 
     assert.equal(event.value.data.type, 'put')
@@ -20,14 +20,19 @@ describe('Prolly', () => {
     assert.equal(head.length, 1)
     assert.equal(head[0].toString(), event.cid.toString())
 
-    console.log('alive event', event)
+    console.log('alive event', event.cid)
     // next steps to debug <- *****************************************************************
     // log the CIDs and their values that are written by the putAndVis
     // log the CIDs and their values that are read by the get
     const avalue = await alice.get('key')
     assert(avalue)
     console.log('prolly avalue', avalue)
-    assert.equal(avalue.toString(), value.toString())
+
+    for (const entry of blocks.entries()) {
+      console.log('entry', entry.cid)
+    }
+
+    assert.equal(JSON.stringify(avalue), JSON.stringify(value))
   })
 
   it('linear put multiple values', async () => {
@@ -109,7 +114,6 @@ class TestPail {
    * @param {import('../link').AnyLink} value
    */
   async put (key, value) {
-    // console.log('prolly put', key, value)
     // for (const { cid } of this.blocks.entries()) {
     //   console.log('bl', cid)
     // }
@@ -119,6 +123,7 @@ class TestPail {
     result.additions.forEach(a => this.blocks.putSync(a.cid, a.bytes))
     this.head = result.head
     this.root = await root(this.blocks, this.head)
+    console.log('prolly PUT', key, value, { head: result.head, additions: result.additions.map(a => a.cid), event: result.event.cid })
     return result
   }
 

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -18,6 +18,11 @@ describe('Prolly', () => {
     assert.equal(event.value.data.value.toString(), value.toString())
     assert.equal(head.length, 1)
     assert.equal(head[0].toString(), event.cid.toString())
+
+    const avalue = await alice.get('key')
+    assert(avalue)
+    console.log('prolly avalue', avalue)
+    assert.equal(avalue.toString(), value.toString())
   })
 
   it('linear put multiple values', async () => {

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -93,25 +93,29 @@ class TestPail {
     this.root = null
   }
 
-  /** @param {import('../clock').EventLink<import('../crdt').EventData>} event */
-  async advance (event) {
-    this.head = await advance(this.blocks, this.head, event)
-    this.root = await root(this.blocks, this.head)
-    return this.head
-  }
-
   /**
    * @param {string} key
    * @param {import('../link').AnyLink} value
    */
   async put (key, value) {
+    // console.log('prolly put', key, value)
+    // for (const { cid } of this.blocks.entries()) {
+    //   console.log('bl', cid)
+    // }
     const result = await put(this.blocks, this.head, key, value)
-
+    if (!result) { console.log('failed', key, value) }
     this.blocks.putSync(result.event.cid, result.event.bytes)
     result.additions.forEach(a => this.blocks.putSync(a.cid, a.bytes))
     this.head = result.head
     this.root = await root(this.blocks, this.head)
     return result
+  }
+
+  /** @param {import('../clock').EventLink<import('../crdt').EventData>} event */
+  async advance (event) {
+    this.head = await advance(this.blocks, this.head, event)
+    this.root = await root(this.blocks, this.head)
+    return this.head
   }
 
   /**
@@ -136,6 +140,7 @@ class TestPail {
 
   /** @param {string} key */
   async get (key) {
+    console.log('this.head', this.head)
     return get(this.blocks, this.head, key)
   }
 }

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -99,6 +99,11 @@ describe('Prolly', () => {
       const vx = await alice.get(key)
       assert.equal(vx.toString(), value.toString())
     }
+    let count = 0
+    for (const _entry of blocks.entries()) {
+      count++
+    }
+    console.log('blocks', count)
   }).timeout(10000)
 })
 

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -129,7 +129,9 @@ class TestPail {
     this.blocks.putSync(result.event.cid, result.event.bytes)
     result.additions.forEach(a => this.blocks.putSync(a.cid, a.bytes))
     this.head = result.head
-    this.root = await root(this.blocks, this.head)
+    this.root = result.root.cid
+    // this difference probably matters, but we need to test it
+    // this.root = await root(this.blocks, this.head)
     // console.log('prolly PUT', key, value, { head: result.head, additions: result.additions.map(a => a.cid), event: result.event.cid })
     return result
   }

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -106,6 +106,7 @@ class TestPail {
    */
   async put (key, value) {
     const result = await put(this.blocks, this.head, key, value)
+
     this.blocks.putSync(result.event.cid, result.event.bytes)
     result.additions.forEach(a => this.blocks.putSync(a.cid, a.bytes))
     this.head = result.head

--- a/test/prolly.test.js
+++ b/test/prolly.test.js
@@ -1,0 +1,140 @@
+import { describe, it } from 'mocha'
+import assert from 'node:assert'
+import { advance, vis } from '../clock.js'
+
+import { put, get, root } from '../prolly.js'
+import { Blockstore, randomCID } from './helpers.js'
+
+describe('Prolly', () => {
+  it('put a value to a new clock', async () => {
+    const blocks = new Blockstore()
+    const alice = new TestPail(blocks, [])
+    const key = 'key'
+    const value = await randomCID(32)
+    const { event, head } = await alice.putAndVis(key, value)
+
+    assert.equal(event.value.data.type, 'put')
+    assert.equal(event.value.data.key, key)
+    assert.equal(event.value.data.value.toString(), value.toString())
+    assert.equal(head.length, 1)
+    assert.equal(head[0].toString(), event.cid.toString())
+  })
+
+  it('linear put multiple values', async () => {
+    const blocks = new Blockstore()
+    const alice = new TestPail(blocks, [])
+
+    const key0 = 'key0'
+    const value0 = await randomCID(32)
+    await alice.put(key0, value0)
+
+    const key1 = 'key1'
+    const value1 = await randomCID(32)
+    const result = await alice.putAndVis(key1, value1)
+
+    assert.equal(result.event.value.data.type, 'put')
+    assert.equal(result.event.value.data.key, key1)
+    assert.equal(result.event.value.data.value.toString(), value1.toString())
+    assert.equal(result.head.length, 1)
+    assert.equal(result.head[0].toString(), result.event.cid.toString())
+  })
+
+  it('simple parallel put multiple values', async () => {
+    const blocks = new Blockstore()
+    const alice = new TestPail(blocks, [])
+    await alice.put('key0', await randomCID(32))
+    const bob = new TestPail(blocks, alice.head)
+
+    /** @type {Array<[string, import('../link').AnyLink]>} */
+    const data = [
+      ['key1', await randomCID(32)],
+      ['key2', await randomCID(32)],
+      ['key3', await randomCID(32)],
+      ['key4', await randomCID(32)]
+    ]
+
+    const { event: aevent0 } = await alice.put(data[0][0], data[0][1])
+    const { event: bevent0 } = await bob.put(data[1][0], data[1][1])
+    const { event: bevent1 } = await bob.put(data[2][0], data[2][1])
+
+    await alice.advance(bevent0.cid)
+    await alice.advance(bevent1.cid)
+    await bob.advance(aevent0.cid)
+
+    const { event: aevent1 } = await alice.putAndVis(data[3][0], data[3][1])
+
+    await bob.advance(aevent1.cid)
+
+    assert(alice.root)
+    assert(bob.root)
+    assert.equal(alice.root.toString(), bob.root.toString())
+
+    // get item put to bob
+    const avalue = await alice.get(data[1][0])
+    assert(avalue)
+    assert.equal(avalue.toString(), data[1][1].toString())
+
+    // get item put to alice
+    const bvalue = await bob.get(data[0][0])
+    assert(bvalue)
+    assert.equal(bvalue.toString(), data[0][1].toString())
+  })
+})
+
+class TestPail {
+  /**
+   * @param {Blockstore} blocks
+   * @param {import('../clock').EventLink<import('../crdt').EventData>[]} head
+   */
+  constructor (blocks, head) {
+    this.blocks = blocks
+    this.head = head
+    /** @type {import('../shard.js').ShardLink?} */
+    this.root = null
+  }
+
+  /** @param {import('../clock').EventLink<import('../crdt').EventData>} event */
+  async advance (event) {
+    this.head = await advance(this.blocks, this.head, event)
+    this.root = await root(this.blocks, this.head)
+    return this.head
+  }
+
+  /**
+   * @param {string} key
+   * @param {import('../link').AnyLink} value
+   */
+  async put (key, value) {
+    const result = await put(this.blocks, this.head, key, value)
+    this.blocks.putSync(result.event.cid, result.event.bytes)
+    result.additions.forEach(a => this.blocks.putSync(a.cid, a.bytes))
+    this.head = result.head
+    this.root = await root(this.blocks, this.head)
+    return result
+  }
+
+  /**
+   * @param {string} key
+   * @param {import('../link.js').AnyLink} value
+   */
+  async putAndVis (key, value) {
+    const result = await this.put(key, value)
+    /** @param {import('../link').AnyLink} l */
+    const shortLink = l => `${String(l).slice(0, 4)}..${String(l).slice(-4)}`
+    /** @type {(e: import('../clock').EventBlockView<import('../crdt').EventData>) => string} */
+    const renderNodeLabel = event => {
+      return event.value.data.type === 'put'
+        ? `${shortLink(event.cid)}\\nput(${event.value.data.key}, ${shortLink(event.value.data.value)})`
+        : `${shortLink(event.cid)}\\ndel(${event.value.data.key})`
+    }
+    for await (const line of vis(this.blocks, result.head, { renderNodeLabel })) {
+      console.log(line)
+    }
+    return result
+  }
+
+  /** @param {string} key */
+  async get (key) {
+    return get(this.blocks, this.head, key)
+  }
+}


### PR DESCRIPTION
This passes the tests, and I added a basic perf test and improved it by 5x in a couple of hours. I know there's a bit of commented code in there, I wanna see if the bulk changes I just did hold up compared to the old way through some more testing.

My next big move will be to make an indexer, but I think if I do it right I can index both the Pail prefix tree and the prolly tree.

To do that I think I need to:

- [ ] extract a shared core from crdt.js and prolly.js (lots of the code is identical)
- [ ] make it so you can easily make a crdt for pail or prolly.
- [ ] design an indexer that consumes the sorted events and applies them to the index. maybe the indexer should have a rollback capability to handle sync merges more efficiently.
- [ ] I think the indexer contract could be that it consumes car transactions that correspond to applying the diff from old to new state, otherwise we risk having a graph fetch hiding in the contract
- [ ] I guess that means I should work on a car-transaction store with a Blockstore interface. maybe there is already one -- I'm thinking browse File/Blob API with an IndexedDB range offset index.