### PR TITLE
The root should always be returned as an addition, even if it's in the removals

### DIFF
--- a/src/crdt.js
+++ b/src/crdt.js
@@ -96,9 +96,10 @@ export async function put (blocks, head, key, value, options) {
   mblocks.putSync(event.cid, event.bytes)
   head = await Clock.advance(blocks, head, event.cid)
 
-  // filter blocks that were added _and_ removed
+  // filter blocks that were added _and_ removed, except for the root
+  const rootCidString = result.root.toString()
   for (const k of removals.keys()) {
-    if (additions.has(k)) {
+    if (additions.has(k) && k !== rootCidString) {
       additions.delete(k)
       removals.delete(k)
     }

--- a/test/crdt.test.js
+++ b/test/crdt.test.js
@@ -136,6 +136,24 @@ describe('CRDT', () => {
       assert(v.toString(), new Map(data).get(k)?.toString())
     }
   })
+
+  it('root in additions', async () => {
+    const blocks = new Blockstore()
+    const alice = new TestPail(blocks, [])
+
+    const key0 = 'key0'
+    const value0 = await randomCID(32)
+
+    const r1 = await alice.put(key0, value0)
+    const root1 = r1.root.toString()
+    const add1 = r1.additions.map(a => a.cid.toString())
+    assert(add1.indexOf(root1) !== -1)
+
+    const r2 = await alice.put(key0, value0)
+    const root2 = r2.root.toString()
+    const add2 = r2.additions.map(a => a.cid.toString())
+    assert(add2.indexOf(root2) !== -1)
+  })
 })
 
 class TestPail {


### PR DESCRIPTION
This code makes a sticky case in real-world testing clean right up. 

I can share a screen-cast with you but hopefully the included test case works.