### PR TITLE
fix: put same value to existing key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,11 @@ export async function put (blocks, root, key, value, options = {}) {
     child = await encodeShardBlock(shard, target.prefix)
   }
 
+  // if no change in the target then we're done
+  if (child.cid.toString() === target.cid.toString()) {
+    return { root, additions: [], removals: [] }
+  }
+
   additions.push(child)
 
   // path is root -> shard, so work backwards, propagating the new shard CID

--- a/test/crdt.test.js
+++ b/test/crdt.test.js
@@ -12,6 +12,7 @@ describe('CRDT', () => {
     const value = await randomCID(32)
     const { event, head } = await alice.putAndVis(key, value)
 
+    assert(event)
     assert.equal(event.value.data.type, 'put')
     assert.equal(event.value.data.key, key)
     assert.equal(event.value.data.value.toString(), value.toString())
@@ -31,6 +32,7 @@ describe('CRDT', () => {
     const value1 = await randomCID(32)
     const result = await alice.putAndVis(key1, value1)
 
+    assert(result.event)
     assert.equal(result.event.value.data.type, 'put')
     assert.equal(result.event.value.data.key, key1)
     assert.equal(result.event.value.data.value.toString(), value1.toString())
@@ -56,10 +58,16 @@ describe('CRDT', () => {
     const { event: aevent0 } = await alice.put(data[0][0], data[0][1])
     const { event: bevent0 } = await bob.put(data[1][0], data[1][1])
 
+    assert(aevent0)
+    assert(bevent0)
+
     const carol = new TestPail(blocks, bob.head)
 
     const { event: bevent1 } = await bob.put(data[2][0], data[2][1])
     const { event: cevent1 } = await carol.put(data[3][0], data[3][1])
+
+    assert(bevent1)
+    assert(cevent1)
 
     await alice.advance(cevent1.cid)
     await alice.advance(bevent0.cid)
@@ -67,6 +75,8 @@ describe('CRDT', () => {
     await bob.advance(aevent0.cid)
 
     const { event: aevent1 } = await alice.putAndVis(data[4][0], data[4][1])
+
+    assert(aevent1)
 
     await bob.advance(aevent1.cid)
     await carol.advance(aevent1.cid)
@@ -108,6 +118,8 @@ describe('CRDT', () => {
     await alice.put(data[0][0], data[0][1])
     const { event } = await bob.put(data[1][0], data[1][1])
 
+    assert(event)
+
     await alice.advance(event.cid)
     const value = await alice.get(data[1][0])
 
@@ -130,11 +142,36 @@ describe('CRDT', () => {
     await alice.put(data[0][0], data[0][1])
     const { event } = await bob.put(data[1][0], data[1][1])
 
+    assert(event)
+
     await alice.advance(event.cid)
 
     for await (const [k, v] of alice.entries()) {
       assert(v.toString(), new Map(data).get(k)?.toString())
     }
+  })
+
+  it('put same value to existing key', async () => {
+    const blocks = new Blockstore()
+    const alice = new TestPail(blocks, [])
+
+    const key0 = 'key0'
+    const value0 = await randomCID(32)
+
+    const r0 = await alice.put(key0, value0)
+    assert(r0.additions.map(s => s.cid.toString()).includes(r0.root.toString()))
+    assert(!r0.removals.map(s => s.cid.toString()).includes(r0.root.toString()))
+
+    const r1 = await alice.put(key0, value0)
+
+    // nothing was added or removed
+    assert.equal(r1.root.toString(), r0.root.toString())
+    assert.equal(r1.additions.length, 0)
+    assert.equal(r1.removals.length, 0)
+
+    // no event should have been added to the clock
+    assert.deepEqual(r1.head.map(cid => cid.toString()), r0.head.map(cid => cid.toString()))
+    assert.equal(r1.event, undefined)
   })
 })
 
@@ -165,7 +202,7 @@ class TestPail {
    */
   async put (key, value) {
     const result = await put(this.blocks, this.head, key, value)
-    this.blocks.putSync(result.event.cid, result.event.bytes)
+    if (result.event) this.blocks.putSync(result.event.cid, result.event.bytes)
     result.additions.forEach(a => this.blocks.putSync(a.cid, a.bytes))
     this.head = result.head
     this.root = (await root(this.blocks, this.head)).root

--- a/test/put.test.js
+++ b/test/put.test.js
@@ -44,6 +44,32 @@ describe('put', () => {
     assert.equal(result.additions[0].value[0][1].toString(), dataCID.toString())
   })
 
+  it('put same value to existing key', async () => {
+    const root = await ShardBlock.create()
+    const blocks = new Blockstore()
+    await blocks.put(root.cid, root.bytes)
+
+    const dataCID = await randomCID(32)
+    const result0 = await put(blocks, root.cid, 'test', dataCID)
+
+    assert.equal(result0.removals.length, 1)
+    assert.equal(result0.removals[0].cid.toString(), root.cid.toString())
+    assert.equal(result0.additions.length, 1)
+    assert.equal(result0.additions[0].value.length, 1)
+    assert.equal(result0.additions[0].value[0][0], 'test')
+    assert.equal(result0.additions[0].value[0][1].toString(), dataCID.toString())
+
+    for (const b of result0.additions) {
+      await blocks.put(b.cid, b.bytes)
+    }
+
+    const result1 = await put(blocks, result0.root, 'test', dataCID)
+
+    assert.equal(result1.removals.length, 0)
+    assert.equal(result1.additions.length, 0)
+    assert.equal(result1.root.toString(), result0.root.toString())
+  })
+
   it('auto-shards on long key', async () => {
     const root = await ShardBlock.create()
     const blocks = new Blockstore()


### PR DESCRIPTION
refs https://github.com/alanshaw/pail/pull/20

Putting the same value to an existing key should not mutate the pail, and should not add a clock event (since no changes happened).